### PR TITLE
feat(gitlab): add search method and search struct to handle

### DIFF
--- a/addons/gitlab/main.go
+++ b/addons/gitlab/main.go
@@ -57,3 +57,15 @@ func DeleteProjectHooksById(id int, hook_id int) bool {
     RequestHandler.Url = base_url + api_prefix
     return result
 }
+
+func SearchOnProjectById(id int, search string) []SearchResult{
+    var searchResult []SearchResult
+    RequestHandler.Url = RequestHandler.Url + "/projects/" + strconv.Itoa(id) + "/search?scope=blobs&search=" + search
+
+    raw := http.GetRequest(RequestHandler)
+    json.Unmarshal(raw, &searchResult) 
+
+    RequestHandler.Url = base_url + api_prefix
+
+    return searchResult
+}

--- a/addons/gitlab/struct.go
+++ b/addons/gitlab/struct.go
@@ -12,3 +12,15 @@ type Hook struct {
     ProjectId int `json:"project_id"`
     SslEnable bool `json:"enable_ssl_verification"`
 }
+
+type SearchResult struct {
+    Basename string `json:"basename"`
+    Data string `json:"data"`
+    Path string `json:"path"`
+    Filename string `json:"filename"`
+    Id string `json:"id"`
+    Ref string `json:"ref"`
+    Startline string `json:"startline"`
+    Project_id string `json:"project_id"`
+}
+

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -11,8 +11,8 @@ import (
 	"imp/addons/gitlab"
 )
 
-var hook_id int
-var action string
+var hookId int
+var hookAction string
 
 // hooksCmd represents the hook command
 var hooksCmd = &cobra.Command{
@@ -20,10 +20,10 @@ var hooksCmd = &cobra.Command{
 	Short: "Get list of gitlab project hooks",
 	Long: `Get list of gitlab project hooks`,
     Run: func(cmd *cobra.Command, args []string) {
-        switch action {
+        switch hookAction {
         case "delete":
-            if hook_id != -1 {
-                if gitlab.DeleteProjectHooksById(id, hook_id) {
+            if hookId != -1 {
+                if gitlab.DeleteProjectHooksById(projectId, hookId) {
                     fmt.Println("Hook remove succesfully")
                 } else {
                     fmt.Println("ERROR: Hook not remove")
@@ -32,10 +32,10 @@ var hooksCmd = &cobra.Command{
                 fmt.Println("Need a hook-id to delete a hook!")
             }
         default:
-            for _, hook := range gitlab.GetProjectHooksById(id) {
-                if hook_id == -1 {
+            for _, hook := range gitlab.GetProjectHooksById(projectId) {
+                if hookId == -1 {
                     fmt.Println(hook)
-                } else if hook.Id == hook_id {
+                } else if hook.Id == hookId {
                     fmt.Println(hook)
                     break
                 }
@@ -46,8 +46,8 @@ var hooksCmd = &cobra.Command{
 
 func init() {
 	projectCmd.AddCommand(hooksCmd)
-    hooksCmd.PersistentFlags().IntVar(&hook_id, "hook-id", -1, "gitlab hook id")
-    hooksCmd.PersistentFlags().StringVar(&action, "action", "", `Action to do with hook: 
+    hooksCmd.PersistentFlags().IntVar(&hookId, "hook-id", -1, "gitlab hook id")
+    hooksCmd.PersistentFlags().StringVar(&hookAction, "action", "", `Action to do with hook: 
     - delete
     // todo #10 : - update (with more args)
     `)

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -10,7 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var id int
+var projectId int
+var projectAction string
 
 // projectCmd represents the project command
 var projectCmd = &cobra.Command{
@@ -18,11 +19,19 @@ var projectCmd = &cobra.Command{
 	Short: "Get github project by id",
 	Long: `Get github project by id`,
 	Run: func(cmd *cobra.Command, args []string) {
-        fmt.Println(gitlab.GetProjectById(id)) 
+        switch projectAction {
+        case "search-code":
+            fmt.Println(gitlab.SearchOnProjectById(projectId, args[0]))
+        default:
+            fmt.Println(gitlab.GetProjectById(projectId)) 
+        }
 	},
 }
 
 func init() {
 	gitlabCmd.AddCommand(projectCmd)
-    projectCmd.PersistentFlags().IntVar(&id, "id", -1, "gitlab project id")
+    projectCmd.PersistentFlags().IntVar(&projectId, "id", -1, "gitlab project id")
+    projectCmd.PersistentFlags().StringVar(&projectAction, "action", "", `Action to do with hook: 
+    - search-code
+    `)
 }


### PR DESCRIPTION
Now is possible to run `imp gitlab project --id 1234 --action search-code "test"` to search for string in the project

Closes #10